### PR TITLE
Ensure DB sessions close after requests

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -8,4 +8,11 @@ def init_db():
     SQLModel.metadata.create_all(engine)
 
 def get_session():
-    return Session(engine)
+    """Yield a database session and ensure it's closed after use.
+
+    When used as a FastAPI dependency, this will provide a session for the
+    duration of the request and then close it. This prevents connection leaks
+    that occurred when sessions were returned without being properly closed.
+    """
+    with Session(engine) as session:
+        yield session

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from typing import List, Set
 from datetime import datetime, timezone
 import asyncio
 
-from .db import init_db, get_session
+from .db import init_db, get_session, engine
 from .models import Task, TaskCreate, TaskRead, TaskUpdate
 from sqlmodel import Session
 
@@ -108,9 +108,9 @@ async def reminder_scheduler():
     await asyncio.sleep(1)
     while True:
         try:
-            from .db import get_session
             from .models import Task
-            with get_session() as session:
+            # create and close sessions manually in this background task
+            with Session(engine) as session:
                 now = datetime.now(timezone.utc)
                 tasks = session.exec(select(Task).where(Task.completed == False)).all()
                 for t in tasks:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the import path when running tests
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.db import get_session
+from sqlmodel import Session
+
+
+def test_get_session_yields_session():
+    gen = get_session()
+    session = next(gen)
+    try:
+        assert isinstance(session, Session)
+    finally:
+        gen.close()


### PR DESCRIPTION
## Summary
- Return DB sessions with a context-managed generator to close them after API requests
- Use explicit session management in background reminder scheduler
- Add regression test for session dependency

## Testing
- `python -m py_compile backend/db.py backend/main.py tests/test_db.py`
- `pytest tests/test_db.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'kv/app.kv')*

------
https://chatgpt.com/codex/tasks/task_e_68a89a1f3fd883298f0cc036bee16f3a