### PR TITLE
fix: deploy reports to gh-pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
       - main
       - master
   pull_request:
-    branches: ["**"]
 
 permissions:
   contents: read
@@ -22,7 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Pages
-        if: github.event_name == 'push'
         uses: actions/configure-pages@v4
       - name: Install system dependencies
         run: |
@@ -62,14 +60,12 @@ jobs:
           name: html-report
           path: report
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: report
 
   pages:
     needs: tests
-    if: github.event_name == 'push'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -16,6 +21,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Pages
+        if: github.event_name == 'push'
+        uses: actions/configure-pages@v4
       - name: Install system dependencies
         run: |
           sudo apt-get update -y
@@ -35,7 +43,7 @@ jobs:
         run: xvfb-run -a pytest --cov=backend --cov-report=xml --cov-report=html --cov-report=term --junitxml=pytest.xml --html=pytest.html --self-contained-html
       - name: Prepare reports
         run: |
-          mkdir report
+          mkdir -p report
           mv htmlcov report/coverage
           mv pytest.html report/
       - name: Upload coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,9 @@ __marimo__/
 
 # Logs
 .uvicorn.*
+
+# Test report artifacts
+report/*
+!report/index.html
+pytest.html
+pytest.xml

--- a/report/index.html
+++ b/report/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Test Reports</title></head>
+<body>
+<h1>Test Reports</h1>
+<ul>
+  <li><a href="pytest.html">Pytest Report</a></li>
+  <li><a href="coverage/index.html">Coverage Report</a></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure actions to deploy test reports via GitHub Pages
- move report index into repository

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel'; ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c337ea8dd883299e320edf8b1c9d46