### PR TITLE
feat: branch-specific test reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   tests:
@@ -34,14 +32,27 @@ jobs:
           auto-activate-base: false
           use-mamba: true
       - name: Install test dependencies
-        run: conda install -y pytest pytest-asyncio pytest-cov pytest-html
+        run: conda install -y pytest pytest-asyncio pytest-cov pytest-html dateparser
       - name: Run tests
         run: xvfb-run -a pytest --cov=backend --cov-report=xml --cov-report=html --cov-report=term --junitxml=pytest.xml --html=pytest.html --self-contained-html
       - name: Prepare reports
         run: |
-          mkdir -p report
-          mv htmlcov report/coverage
-          mv pytest.html report/
+          branch_dir="report/${GITHUB_REF_NAME}"
+          mkdir -p "${branch_dir}"
+          mv htmlcov "${branch_dir}/coverage"
+          mv pytest.html "${branch_dir}/"
+          cp report/branch_template.html "${branch_dir}/index.html"
+          sed -i "s/__BRANCH__/${GITHUB_REF_NAME}/g" "${branch_dir}/index.html"
+          python - <<'PYTHON'
+import os, pathlib
+branch = os.environ["GITHUB_REF_NAME"]
+index_path = pathlib.Path("report/index.html")
+link = f'  <li><a href="{branch}/index.html">{branch}</a></li>'
+text = index_path.read_text()
+if link not in text:
+    text = text.replace("</ul>", f"{link}\n</ul>")
+    index_path.write_text(text)
+PYTHON
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -56,22 +67,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: html-report
-          path: report
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+          path: report/${GITHUB_REF_NAME}
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: report
-
-  pages:
-    needs: tests
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy reports to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: report
+          keep_files: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,16 +43,7 @@ jobs:
           mv pytest.html "${branch_dir}/"
           cp report/branch_template.html "${branch_dir}/index.html"
           sed -i "s/__BRANCH__/${GITHUB_REF_NAME}/g" "${branch_dir}/index.html"
-          python - <<'PYTHON'
-import os, pathlib
-branch = os.environ["GITHUB_REF_NAME"]
-index_path = pathlib.Path("report/index.html")
-link = f'  <li><a href="{branch}/index.html">{branch}</a></li>'
-text = index_path.read_text()
-if link not in text:
-    text = text.replace("</ul>", f"{link}\n</ul>")
-    index_path.write_text(text)
-PYTHON
+          python scripts/update_report_index.py --index report/index.html --branch "${GITHUB_REF_NAME}"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -220,5 +220,6 @@ __marimo__/
 # Test report artifacts
 report/*
 !report/index.html
+!report/branch_template.html
 pytest.html
 pytest.xml

--- a/report/branch_template.html
+++ b/report/branch_template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Test Reports - __BRANCH__</title></head>
+<body>
+<h1>Test Reports - __BRANCH__</h1>
+<ul>
+  <li><a href="pytest.html">Pytest Report</a></li>
+  <li><a href="coverage/index.html">Coverage Report</a></li>
+</ul>
+</body>
+</html>
+

--- a/report/index.html
+++ b/report/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
-<head><meta charset="UTF-8"><title>Test Reports</title></head>
+<head><meta charset="UTF-8"><title>Branch Test Reports</title></head>
 <body>
-<h1>Test Reports</h1>
+<h1>Branch Test Reports</h1>
 <ul>
-  <li><a href="pytest.html">Pytest Report</a></li>
-  <li><a href="coverage/index.html">Coverage Report</a></li>
+  <!-- Branch report links will be inserted here -->
 </ul>
 </body>
 </html>
+

--- a/scripts/update_report_index.py
+++ b/scripts/update_report_index.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Update the report index with a link to the branch report."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", type=pathlib.Path, required=True, help="Path to the index HTML file.")
+    parser.add_argument("--branch", required=True, help="Branch name to add to the index.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    index_path: pathlib.Path = args.index
+    branch: str = args.branch
+
+    if not index_path.exists():
+        raise FileNotFoundError(f"Index file not found: {index_path}")
+
+    link_html = f'  <li><a href="{branch}/index.html">{branch}</a></li>'
+
+    text = index_path.read_text()
+    if link_html in text:
+        return
+
+    if "</ul>" not in text:
+        raise ValueError("Index file must contain a </ul> tag to insert branch links.")
+
+    updated = text.replace("</ul>", f"{link_html}\n</ul>")
+    index_path.write_text(updated)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate per-branch test report pages via a template
- list branches on GitHub Pages index with links to their reports

## Testing
- `xvfb-run -a pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68c66c9ee3288329a8fce7e487142580